### PR TITLE
Fixed not finding adb due to it looking in the starting working working directory.

### DIFF
--- a/GAMA v1.4.1.2/GAMA.bat
+++ b/GAMA v1.4.1.2/GAMA.bat
@@ -17,7 +17,7 @@ cls
 
 :: Check for any ADB devices
 set adb_status=Disconnected
-for /f "tokens=1" %%A in ('adb get-state 2^>nul') do (
+for /f "tokens=1" %%A in ('"%~dp0\adb" get-state 2^>nul') do (
     if "%%A"=="device" (
         set adb_status=Connected
     )

--- a/GAMA v1.4.1.2/bin/launch_all_apps.bat
+++ b/GAMA v1.4.1.2/bin/launch_all_apps.bat
@@ -13,7 +13,7 @@ echo %CYAN%  = -------------------------------------------------- = %RESET%
 
 timeout /t 5
 cls
-adb shell "for pkg in $(pm list packages | cut -f2 -d:); do monkey -p \"$pkg\" -c android.intent.category.LAUNCHER 1; done" 2>&1 | findstr /v "** No activities found to run"
+"%~dp0\adb" shell "for pkg in $(pm list packages | cut -f2 -d:); do monkey -p \"$pkg\" -c android.intent.category.LAUNCHER 1; done" 2>&1 | findstr /v "** No activities found to run"
 
 if %ERRORLEVEL% neq 0 (
 	color 0C

--- a/GAMA v1.4.1.2/bin/set_vulkan.bat
+++ b/GAMA v1.4.1.2/bin/set_vulkan.bat
@@ -70,12 +70,12 @@ echo       Applying the selected API...
 echo.
 echo %CYAN%  = -------------------------------------------------- =%RESET%
 
-adb shell setprop debug.hwui.renderer %RENDERER%
-adb shell am crash com.android.systemui
-adb shell am force-stop com.android.settings
-adb shell am force-stop com.sec.android.app.launcher
-adb shell am force-stop com.samsung.android.app.aodservice
-adb shell am force-stop com.google.android.inputmethod.latin
+"%~dp0\adb" shell setprop debug.hwui.renderer %RENDERER%
+"%~dp0\adb" shell am crash com.android.systemui
+"%~dp0\adb" shell am force-stop com.android.settings
+"%~dp0\adb" shell am force-stop com.sec.android.app.launcher
+"%~dp0\adb" shell am force-stop com.samsung.android.app.aodservice
+"%~dp0\adb" shell am force-stop com.google.android.inputmethod.latin
 set setprop_status=%ERRORLEVEL%
 
 if %ERRORLEVEL%==0 (
@@ -112,8 +112,8 @@ echo       Applying the selected API...
 echo.
 echo %CYAN%  = -------------------------------------------------- =%RESET%
 
-adb shell setprop debug.hwui.renderer %RENDERER%
-adb shell "for a in $(pm list packages | grep -v ia.mo | cut -f2 -d:); do am force-stop \"$a\"; done" >nul 2>&1
+"%~dp0\adb" shell setprop debug.hwui.renderer %RENDERER%
+"%~dp0\adb" shell "for a in $(pm list packages | grep -v ia.mo | cut -f2 -d:); do am force-stop \"$a\"; done" >nul 2>&1
 
 if %ERRORLEVEL%==0 (
 	color 0A

--- a/GAMA v1.4.1.2/bin/shizuku.bat
+++ b/GAMA v1.4.1.2/bin/shizuku.bat
@@ -13,7 +13,7 @@ echo.
 echo       Starting Shizuku...
 echo.
 echo %CYAN%  = -------------------------------------------------- =%RESET%
-adb shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh
+"%~dp0\adb" shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh
 if %ERRORLEVEL%==0 (
 	color 0A
 	echo.

--- a/GAMA-Core/GAMA-OpenGL/gama-opengl.bat
+++ b/GAMA-Core/GAMA-OpenGL/gama-opengl.bat
@@ -1,7 +1,7 @@
 @echo off
-adb shell setprop debug.hwui.renderer opengl
-adb shell am crash com.android.systemui
-adb shell am force-stop com.android.settings
-adb shell am force-stop com.sec.android.app.launcher
-adb shell am force-stop com.samsung.android.app.aodservice
-adb shell am crash com.google.android.inputmethod.latin b
+"%~dp0\adb" shell setprop debug.hwui.renderer opengl
+"%~dp0\adb" shell am crash com.android.systemui
+"%~dp0\adb" shell am force-stop com.android.settings
+"%~dp0\adb" shell am force-stop com.sec.android.app.launcher
+"%~dp0\adb" shell am force-stop com.samsung.android.app.aodservice
+"%~dp0\adb" shell am crash com.google.android.inputmethod.latin b

--- a/GAMA-Core/GAMA-Vulkan/gama-vulkan.bat
+++ b/GAMA-Core/GAMA-Vulkan/gama-vulkan.bat
@@ -1,7 +1,7 @@
 @echo off
-adb shell setprop debug.hwui.renderer skiavk
-adb shell am crash com.android.systemui
-adb shell am force-stop com.android.settings
-adb shell am force-stop com.sec.android.app.launcher
-adb shell am force-stop com.samsung.android.app.aodservice
-adb shell am crash com.google.android.inputmethod.latin b
+"%~dp0\adb" shell setprop debug.hwui.renderer skiavk
+"%~dp0\adb" shell am crash com.android.systemui
+"%~dp0\adb" shell am force-stop com.android.settings
+"%~dp0\adb" shell am force-stop com.sec.android.app.launcher
+"%~dp0\adb" shell am force-stop com.samsung.android.app.aodservice
+"%~dp0\adb" shell am crash com.google.android.inputmethod.latin b


### PR DESCRIPTION
script can't find adb as the CWD isn't changed when another batch file is called. Using `%~dp0`, we can just get the path to where the current script is running from and assume that's where adb is.